### PR TITLE
Update scrollTop with getBoundingClientRect().height

### DIFF
--- a/script/jquery.jscrollpane.js
+++ b/script/jquery.jscrollpane.js
@@ -189,7 +189,7 @@
 				} else {
 					contentWidth = pane[0].scrollWidth;
 				}
-				contentHeight = pane[0].scrollHeight;
+				contentHeight = pane[0].getBoundingClientRect().height;
 				pane.css('overflow', '');
 
 				percentInViewH = contentWidth / paneWidth;


### PR DESCRIPTION
getBoundingClientRect().height calc correct box height instead scrollTop add horizontal scrollbar height also if isn't visible.